### PR TITLE
update the browserify guide

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -136,11 +136,6 @@ By default, Spark ships with support for Webpack. If you prefer using Browserify
 
 The [Aliasify](https://github.com/benbria/aliasify) package instructs Browserify to load the standalone build of Vue 2.0, which includes the compiler needed to render Spark's templates. Once these dependencies have been added to your project, you should add the following additional entries to your `package.json` file:
 
-	"browserify": {
-		"transform": [
-		    "aliasify"
-		]
-	},
 	"aliasify": {
 		"aliases": {
 		    "vue": "vue/dist/vue.js"
@@ -152,7 +147,7 @@ Finally, update your `gulpfile.js` and replace `webpack` with `browserify`:
 ```javascript
 elixir(function(mix) {
     mix.less('app.less')
-        .browserify('app.js', null, null, { paths: 'vendor/laravel/spark/resources/assets/js' })
+        .browserify('app.js', null, null, { paths: ['vendor/laravel/spark/resources/assets/js'], transform: ["aliasify"]})
         .copy('node_modules/sweetalert/dist/sweetalert.min.js', 'public/js/sweetalert.min.js')
         .copy('node_modules/sweetalert/dist/sweetalert.css', 'public/css/sweetalert.css');
 });


### PR DESCRIPTION
Looks like we'll need to update the browserify guide, it turned out that browserify will look at the first package.json it finds moving up the directory tree, and in this case it's the one included in `vendor/spark`, so we need to either update it to have the alisaify transformer or have it in the options parameter of elixir.browserify

```
{paths: ['vendor/laravel/spark/resources/assets/js'], transform: ["aliasify"]}
```