### PR TITLE
Replace Vue 1.0 ready() and $dispatch code

### DIFF
--- a/adding-profile-fields.md
+++ b/adding-profile-fields.md
@@ -94,7 +94,7 @@ Next, we will define the new `update-profile-details` Vue component which will m
             update() {
                 Spark.put('/settings/profile/details', this.form)
                     .then(response => {
-                        this.$emit('updateUser');
+                        Bus.$emit('updateUser');
                     });
             }
         }

--- a/adding-profile-fields.md
+++ b/adding-profile-fields.md
@@ -86,7 +86,7 @@ Next, we will define the new `update-profile-details` Vue component which will m
             };
         },
 
-        ready() {
+        mounted() {
             this.form.age = this.user.age;
         },
 
@@ -94,7 +94,7 @@ Next, we will define the new `update-profile-details` Vue component which will m
             update() {
                 Spark.put('/settings/profile/details', this.form)
                     .then(response => {
-                        this.$dispatch('updateUser');
+                        this.$emit('updateUser');
                     });
             }
         }

--- a/available-variables.md
+++ b/available-variables.md
@@ -19,7 +19,7 @@ You may ask for the `user`, `teams`, or `currentTeam` properties in your Vue com
     Vue.component('home', {
         props: ['user', 'teams', 'currentTeam'],
 
-        ready() {
+        mounted() {
             //
         }
     });
@@ -38,7 +38,7 @@ You may also access data using the `Spark.state` object. For example, let's do t
     Vue.component('home', {
         props: ['user'],
 
-        ready() {
+        mounted() {
             console.log(Spark.state.user);
             console.log(Spark.state.teams);
             console.log(Spark.state.currentTeam);


### PR DESCRIPTION
Since Spark 3.0 uses Vue 2.0, I noticed the doc examples were outdated. I simply replaced the instances of `ready()` with `mounted()` and `$dispatch` with `$emit`.