### PR TITLE
Changing examples using this.$http to axios since this.$http does not fill headers with CSRF token any longer.

### DIFF
--- a/api.md
+++ b/api.md
@@ -68,7 +68,7 @@ Spark makes it entirely painless to consume your API in this way. Simply make re
 
 So, if you are using Vue, you may simply call your API routes like normal. No additional configuration is necessary to start consuming your API:
 
-    this.$http.get('/api/users')
+    axios.get('/api/users')
         .then(response => {
             this.users = response.data;
         });

--- a/upgrade.md
+++ b/upgrade.md
@@ -63,9 +63,9 @@ Once you have created your `webpack.mix.js` file, update the first line of your 
 
     @import "./../../../node_modules/bootstrap/less/bootstrap";
 
-Once you have made these changes, you can run `npm install` and `npm run dev` to compile your assets using Mix.
-
 Replace any usage of `this.$http` with `axios` if you are doing any calls where you expect the CSRF token to be passed to an internally used API.
+
+Once you have made these changes, you can run `npm install` and `npm run dev` to compile your assets using Mix.
 
 <a name="upgrade-spark-3.0"></a>
 ## Upgrading To Spark 3.0

--- a/upgrade.md
+++ b/upgrade.md
@@ -65,6 +65,8 @@ Once you have created your `webpack.mix.js` file, update the first line of your 
 
 Once you have made these changes, you can run `npm install` and `npm run dev` to compile your assets using Mix.
 
+Replace any usage of `this.$http` with `axios` if you are doing any calls where you expect the CSRF token to be passed to an internally used API.
+
 <a name="upgrade-spark-3.0"></a>
 ## Upgrading To Spark 3.0
 


### PR DESCRIPTION
Changing `this.$http` to `axios` in the example.  `this.$http` does not populate the headers with the `X-CSRF-TOKEN` any longer.