### PR TITLE
Add Bootstrap class to adding profile fields example

### DIFF
--- a/adding-profile-fields.md
+++ b/adding-profile-fields.md
@@ -57,7 +57,7 @@ This `@include` directive will load a new Blade template which contains our cust
                     </div>
 
                     <!-- Update Button -->
-                    <div class="form-group">
+                    <div class="form-group row">
                         <div class="col-md-6 offset-md-4">
                             <button type="submit" class="btn btn-primary"
                                     @click.prevent="update"


### PR DESCRIPTION
Copying and pasting the "Adding Profile Fields" Blade example had inconsistent spacing between the input(s) and update button. When compared to existing Spark fields, the difference is that the button `.form-group` has a `.row` class.

**Screenshot from pasted code** (misaligned)

<img width="385" alt="Screen Shot 2019-07-28 at 8 49 51 PM" src="https://user-images.githubusercontent.com/3144140/62016844-f456d000-b179-11e9-80ec-27cdbaa8b4bd.png">

**Screenshot from existing Spark code** (aligned 👍)

<img width="390" alt="Screen Shot 2019-07-28 at 8 49 59 PM" src="https://user-images.githubusercontent.com/3144140/62016887-26683200-b17a-11e9-86e3-8ab153aeda38.png">

I hope this helps my fellow copy-pasters. Thank you all. 🙏 