### PR TITLE
Fix typo in the Announcements event documentation

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -15,4 +15,4 @@ The announcement text supports Markdown, so feel free to use Markdown syntax wit
 <a name="announcement-events"></a>
 ## Announcement Events
 
-When an announcement is created, the `Laravel\Spark\Events\Kiosk\AnnouncementCreated` event is dispatched, allowing you to perform additional actions such as sending an announcement push notification, etc.
+When an announcement is created, the `Laravel\Spark\Events\AnnouncementCreated` event is dispatched, allowing you to perform additional actions such as sending an announcement push notification, etc.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/304159/63179574-6eac9e80-c01a-11e9-9991-1db09364de41.png)
