### PR TITLE
Add dot for consistency

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -148,5 +148,5 @@ Replace the following line:
 With this:
 
 ```
-copy('node_modules/sweetalert2/dist/sweetalert2.min.js', 'public/js/sweetalert.min.js')
+.copy('node_modules/sweetalert2/dist/sweetalert2.min.js', 'public/js/sweetalert.min.js')
 ```


### PR DESCRIPTION
The upgrade guide instructs to replace a line in the `webpack.mix.js` file, but inconsistently uses the leading `.` for the commands.  Since the line being replaced has the leading `.`, the replacement line should as well.