### PR TITLE
Bugfix - missing call to spark class

### DIFF
--- a/adding-profile-fields.md
+++ b/adding-profile-fields.md
@@ -24,7 +24,7 @@ The "profile" tab of the settings dashboard contains several panels that allow t
             @include('spark::settings.profile.update-contact-information')
 
             <!-- Update Profile Details -->
-            @include('settings.profile.update-profile-details')
+            @include('spark::settings.profile.update-profile-details')
         </div>
     </spark-profile>
 


### PR DESCRIPTION
In the new "update-profile-details" template, the @include is missing the call to "spark::" on line 10: [@include('settings.profile.update-profile-details')]. This causes an immediate "cannot locate the file" error.